### PR TITLE
fix: fetching blockchain + chainId when input contract

### DIFF
--- a/src/features/misc/listing-form/components/ui/multi-input-template/index.tsx
+++ b/src/features/misc/listing-form/components/ui/multi-input-template/index.tsx
@@ -1,9 +1,9 @@
+import axios from "axios";
 import { blockchainsContentWithNonEVM } from "mobula-lite/lib/chains/constants";
-import React, { ChangeEvent } from "react";
+import { ChangeEvent } from "react";
 import { AiOutlineClose } from "react-icons/ai";
 import { LargeFont, MediumFont } from "../../../../../../components/fonts";
 import { NextImageFallback } from "../../../../../../components/image";
-import { fetchContract } from "../../../../../../layouts/swap/utils";
 import { ACTIONS } from "../../../reducer";
 import { inputStyle } from "../../../styles";
 
@@ -46,25 +46,28 @@ export const MultiInputTemplate = ({
       },
     });
     const getBlockchain = async (address: string) => {
-      const fetchResults = await Promise.all(fetchContract(address));
-      const { blockchain: blockchainBuffer } =
-        fetchResults.filter((entry) => entry)[0] || {};
+      const response: any = await axios.get(
+        `https://general-api-preprod-fgpupeioaa-uc.a.run.app/api/1/metadata?asset=${address}`
+      );
+      const blockchainName = response.data.data.blockchains[0];
+
+      const { chainId } = blockchainsContentWithNonEVM[blockchainName];
+
       dispatch({
         type: ACTIONS.SET_ELEMENT,
         payload: {
           i,
           name: "blockchain",
-          value: blockchainBuffer,
+          value: blockchainName,
           object,
         },
       });
-      const { evmChainId } = blockchainsContentWithNonEVM[blockchainBuffer];
       dispatch({
         type: ACTIONS.SET_ELEMENT,
         payload: {
           i,
           name: "blockchain_id",
-          value: evmChainId,
+          value: chainId,
           object,
         },
       });
@@ -74,8 +77,8 @@ export const MultiInputTemplate = ({
             type: ACTIONS.INITIAL_CONTRACT,
             payload: {
               address: e.target.value,
-              blockchain: blockchainBuffer,
-              blockchain_id: evmChainId,
+              blockchain: blockchainName,
+              blockchain_id: chainId,
             },
           });
     };

--- a/src/features/misc/listing-form/components/ui/multi-input-template/index.tsx
+++ b/src/features/misc/listing-form/components/ui/multi-input-template/index.tsx
@@ -1,9 +1,10 @@
 import axios from "axios";
 import { blockchainsContentWithNonEVM } from "mobula-lite/lib/chains/constants";
-import { ChangeEvent } from "react";
+import React, { ChangeEvent } from "react";
 import { AiOutlineClose } from "react-icons/ai";
 import { LargeFont, MediumFont } from "../../../../../../components/fonts";
 import { NextImageFallback } from "../../../../../../components/image";
+import { API_ENDPOINT } from "../../../../../../constants";
 import { ACTIONS } from "../../../reducer";
 import { inputStyle } from "../../../styles";
 
@@ -47,7 +48,7 @@ export const MultiInputTemplate = ({
     });
     const getBlockchain = async (address: string) => {
       const response: any = await axios.get(
-        `https://general-api-preprod-fgpupeioaa-uc.a.run.app/api/1/metadata?asset=${address}`
+        `${API_ENDPOINT}/api/1/metadata?asset=${address}`
       );
       const blockchainName = response.data.data.blockchains[0];
 


### PR DESCRIPTION
We will now call api/1/metadata to fetch the chain and chainId when we input a contract in the listing form to handle non-EVM contracts.